### PR TITLE
Integrate db_config in all PHP scripts

### DIFF
--- a/CRM/dashboard.php
+++ b/CRM/dashboard.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'db_config.php';
 
 // --- Blocco Debug e Configurazione Sessione/Log ---
 ini_set('log_errors', 1);

--- a/CRM/gestioneutenze.php
+++ b/CRM/gestioneutenze.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'db_config.php';
 
 // --- Blocco Debug e Configurazione Sessione/Log ---
 ini_set('log_errors', 1);
@@ -32,7 +33,6 @@ $gruppi_lavoro = [
 
 
 // --- Connessione al Database e logica per la gestione utenti ---
-$db_host = 'localhost'; $db_user = 'root'; $db_pass = ''; $db_name = 'gruppo_vitolo_db';
 $conn_gu = new mysqli($db_host, $db_user, $db_pass, $db_name);
 
 $users_list = [];

--- a/CRM/hash.php
+++ b/CRM/hash.php
@@ -1,4 +1,5 @@
 <?php
+require_once 'db_config.php';
 $password_per_admin = 'users';
 $nuovo_hash_corretto = password_hash($password_per_admin, PASSWORD_DEFAULT);
 echo "Il nuovo hash CORRETTO per la password 'admin' è: <br><b>" . htmlspecialchars($nuovo_hash_corretto) . "</b><br>";

--- a/CRM/logger.php
+++ b/CRM/logger.php
@@ -1,4 +1,5 @@
 <?php
+require_once 'db_config.php';
 function logUserAction($message) {
     $logFile = __DIR__ . '/user_actions.log';
     $timestamp = date('Y-m-d H:i:s');

--- a/CRM/login.php
+++ b/CRM/login.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'db_config.php';
 
 if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
     header("Location: dashboard.php");
@@ -11,10 +12,6 @@ ini_set('display_errors', 0);
 ini_set('log_errors', 1);
 ini_set('error_log', 'C:/xampp/php_error.log');
 
-$db_host = 'localhost';
-$db_user = 'root';
-$db_pass = '';
-$db_name = 'gruppo_vitolo_db';
 $login_error = '';
 
 error_log("--- Inizio tentativo di login (con ruoli) --- [" . date("Y-m-d H:i:s") . "]");

--- a/CRM/logout.php
+++ b/CRM/logout.php
@@ -1,5 +1,6 @@
 <?php
 session_start(); // Accedi alla sessione
+require_once 'db_config.php';
 session_unset(); // Rimuovi tutte le variabili di sessione
 session_destroy(); // Distruggi la sessione
 header("Location: login.php"); // Reindirizza alla pagina di login

--- a/CRM/rispondi_a_admin.php
+++ b/CRM/rispondi_a_admin.php
@@ -1,5 +1,6 @@
 <?php
-require 'connessione.php'; // connessione al DB
+require_once 'db_config.php';
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $id = filter_input(INPUT_POST, 'id_segnalazione', FILTER_VALIDATE_INT);

--- a/CRM/submit_order_action.php
+++ b/CRM/submit_order_action.php
@@ -1,11 +1,6 @@
 <?php
 session_start();
-
-// Dettagli connessione DB (gli stessi usati negli altri file)
-$db_host = 'localhost';
-$db_user = 'root';
-$db_pass = '';
-$db_name = 'gruppo_vitolo_db';
+require_once 'db_config.php';
 
 // Log per il debug
 ini_set('log_errors', 1);

--- a/CRM/view_logs.php
+++ b/CRM/view_logs.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'db_config.php';
 require_once 'logger.php';
 
 // Consentire accesso solo agli admin


### PR DESCRIPTION
## Summary
- unify DB configuration usage across the app
- remove redundant DB variable assignments

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_684937547e78832daaf8f3ecd67d3825